### PR TITLE
Changed cursor to be a pointer when hovering over search history items

### DIFF
--- a/assets/styles/styles.css
+++ b/assets/styles/styles.css
@@ -30,3 +30,9 @@
 .visible {
     visibility: visible;
 }
+
+/* Changes the cursor to a pointer when hovering over seatch history items */
+#searchHistoryDiv p {
+    cursor: pointer;
+}
+


### PR DESCRIPTION
Cursor now changes to be a pointer when hovering over search history items. This is so that the user knows that they are able to click on them.